### PR TITLE
chrome: check for binary in known locations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Mark the file as binary, so that Git won't not convert the line endings.
+# Otherwise, the file becomes unreadable for bash inside Docker (on Windows platforms).
+entrypoint.sh -text
+

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,18 +28,7 @@ jobs:
       shell: powershell
 
     - name: Check Chrome Version
-      run: '& "C:\Program Files\Google\Chrome\Application\chrome.exe" --version'
-      shell: powershell
-
-    - name: Add Chrome to PATH
-      run: |
-        $chromePath = "C:\Program Files\Google\Chrome\Application"
-        echo "Adding $chromePath to PATH"
-        echo "$chromePath" | Out-File -Append -Encoding utf8 $env:GITHUB_PATH
-      shell: powershell
-
-    - name: Verify Chrome Installation
-      run: chrome --version
+      run: '(Get-Item "C:\Program Files\Google\Chrome\Application\chrome.exe").VersionInfo'
       shell: powershell
 
     - name: Upgrade pip

--- a/tests/integration/lit.cfg
+++ b/tests/integration/lit.cfg
@@ -23,3 +23,9 @@ config.suffixes = ['.itest', '.c']
 config.is_windows = lit_config.isWindows
 if not lit_config.isWindows:
     config.available_features.add('PLATFORM_IS_NOT_WINDOWS')
+
+# In Linux CI, $HOME is required for Chrome as it needs to access things in ~/.local
+config.environment['HOME'] = os.environ.get('HOME', '/tmp')
+
+# In Windows CI, %ProgramW6432% is required for Selenium to properly detect browsers
+config.environment['ProgramW6432'] = os.environ.get('ProgramW6432', '')


### PR DESCRIPTION
This PR tries to address #28 by:

- add entrypoint.sh to .gitattributes so that it keeps the line-endings (Windows/Docker)
- On Windows, chrome.exe is not in $PATH, remove it from the CI environment
- CI: don't remove $HOME or %PROGRAMW6432% in environment sanitation (lit) as Chrome / Selenium depend on these
- make mypy happy
